### PR TITLE
Add webrick explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Required for local serving as of ruby 3+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -73,6 +74,7 @@ DEPENDENCIES
   jekyll-feed
   minima (~> 2.0)
   tzinfo-data
+  webrick (~> 1.8)
 
 RUBY VERSION
    ruby 3.0.2p107


### PR DESCRIPTION
As of Ruby version 3.0.0 or higher, webrick must be explicitly stated in the dependencies.

https://jekyllrb.com/docs/